### PR TITLE
emit 'ready' when DB has been fully initialized

### DIFF
--- a/index.js
+++ b/index.js
@@ -102,14 +102,16 @@ MinkeLite.prototype.shutdown = function (cb) {
     clearInterval(this.model_builder)
     this.model_builder = null
   }
-  if ( this.db ){
-    this.db.close()
-    this.db = null
+  var tasks = [];
+  if (this.express_server) {
+    tasks.push(this.express_server.close.bind(this.express_server))
   }
-  if ( this.express_server ){
-    this.express_server.close()
-    this.express_server = null
+  if (this.db) {
+    tasks.push(this.db.close.bind(this.db))
   }
+  this.db = null
+  this.express_server = null
+  async.series(tasks, cb)
 }
 
 MinkeLite.prototype.get_express_app = function () {

--- a/test/test-api.js
+++ b/test/test-api.js
@@ -24,10 +24,6 @@ var TRANSACTION = "request GET http://localhost:8123/";
 // cd minkelite
 // node ./node_modules/tap/bin/tap.js test/test-api.js
 
-tap.on('end', function(){
-  ML.shutdown();
-});
-
 tap.test('emits "ready" when ready', function(t) {
   ML.on('ready', function() {
     t.ok(true, 'sqlite3 DB is ready for writing');
@@ -107,3 +103,9 @@ tap.test('getTransaction Test', function(t) {
   });
 });
 
+tap.test('shutdown', function(t) {
+  ML.shutdown(function(err) {
+    t.ifError(err, 'should shutdown cleanly');
+    t.end();
+  });
+});


### PR DESCRIPTION
There is a general problem with this module attempting to write to the
DB before it has been fully created and the first step is adding a
mechanism for observing that state.

Alternative fix to #3 
