### PR TITLE
edison support in strongloop environment

### DIFF
--- a/index.js
+++ b/index.js
@@ -1138,7 +1138,7 @@ function freePfkey(pfkey){
 }
 
 function isEdison(act){
-  return act.indexOf("edison:")==0
+  return /^edison/.test(act)
 }
 
 function parseInteger(str){


### PR DESCRIPTION
Edison support is enabled when the account name starts with "Edison:" which does not work anymore with strong-trace because we use package name as the account name.  Colon is not allowed in package name.

connect to strongloop-internal/scrum-nodeops#499
