### PR TITLE
deps: depend on node-sqlite3 from git

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,13 +25,13 @@
     "posttest": "nyc report --reporter=lcov && nyc report"
   },
   "dependencies": {
-    "md5": "~2.0.0",
     "ago": "~1.0.0",
     "async": "~0.9.0",
     "body-parser": "~1.9.0",
     "debug": "^2.2.0",
     "express": "~4.9.6",
-    "sqlite3": "~3.0.6",
+    "md5": "~2.0.0",
+    "sqlite3": "mapbox/node-sqlite3#5a2939d",
     "stats-lite": "~1.0.3",
     "util": "~0.10.3",
     "xtend": "~4.0.0"


### PR DESCRIPTION
The commit is marked as 3.0.11 but has not yet been tagged and released.
The only change in it is the upgrade to nan@2, which allows building
against iojs-v3 and node-v4.

This is a temporary hack for strongloop-internal/scrum-nodeops#901

The commit being used is https://github.com/mapbox/node-sqlite3/commit/5a2939d0f1a0929c0541a2a8dce327dc38d26421