### PR TITLE
deps: use official sqlite3 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "debug": "^2.2.0",
     "express": "~4.9.6",
     "md5": "~2.0.0",
-    "sqlite3": "mapbox/node-sqlite3#5a2939d",
+    "sqlite3": "^3.1.0",
     "stats-lite": "~1.0.3",
     "util": "~0.10.3",
     "xtend": "~4.0.0"


### PR DESCRIPTION
3.1.0 was released with support for iojs-3/node-4.